### PR TITLE
Only install in bash_profile if file exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,11 @@ echo "fi"
 
 SOURCE_JABBA="\n[ -s \"$JABBA_DIR/jabba.sh\" ] && source \"$JABBA_DIR/jabba.sh\""
 
-files=("$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile")
+files=("$HOME/.bashrc" "$HOME/.profile")
+if [ -f "$HOME/.bash_profile" ]; then
+    files+=("$HOME/.bash_profile")
+fi
+
 for file in "${files[@]}"
 do
     touch ${file}


### PR DESCRIPTION
Currently the bash installation always appends to `~/.profile`, `~/.bash_profile`, and `~/.bashrc`. This broke my local environment as I do not use `~/.bash_profile`. When installing jabba, it created `~/.bash_profile`. That caused my `~/.profile` to no longer be loaded. 

This change will only append to `~/.bash_profile` if it already exists. These checks could probably be taken further, like [nvm's install](https://github.com/creationix/nvm/blob/master/install.sh#L178). For example, installing to both `~/.profile` and `~/.bashrc` seems unnecessary.