### PR TITLE
Added batch wrapper to support cmd.exe, slight powershell rework

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -42,22 +42,11 @@ If the problem persists - please create a ticket at https://github.com/shyiko/ja
     exit 1
 }
 
-echo @"
-`$env:JABBA_HOME="$jabbaHome"
+# Get the jabba powershell wrapper.
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/shyiko/jabba/$jabbaVersion/jabba.ps1 -OutFile $jabbaHome/jabba.ps1
 
-function jabba
-{
-    `$fd3=`$([System.IO.Path]::GetTempFileName())
-    `$command="$jabbaHome\bin\jabba.exe `$args --fd3 `$fd3"
-    & { `$env:JABBA_SHELL_INTEGRATION="ON"; Invoke-Expression `$command }
-    `$fd3content=`$(cat `$fd3)
-    if (`$fd3content) {
-        `$expression=`$fd3content.replace("export ","```$env:") -join "``n"
-        if (-not `$expression -eq "") { Invoke-Expression `$expression }
-    }
-    rm -Force `$fd3
-}
-"@ > $jabbaHome/jabba.ps1
+# Get the jabba batchscript wrapper.
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/shyiko/jabba/$jabbaVersion/jabba.bat -OutFile $jabbaHome/jabba.bat
 
 $sourceJabba="if (Test-Path `"$jabbaHome\jabba.ps1`") { . `"$jabbaHome\jabba.ps1`" }"
 
@@ -79,5 +68,10 @@ else
 . "$jabbaHome\jabba.ps1"
 
 echo ""
-echo "Installation completed`
-(if you have any problems please report them at https://github.com/shyiko/jabba/issue)"
+echo "Installation completed!"
+echo ""
+echo "You will be able to use jabba directly from your PowerShell environment."
+echo "if you want to use jabba from a cmd.exe command prompt, copy $jabbaHome\jabba.bat"
+echo "to a directory on your PATH or add $jabbaHome to your PATH environment variable."
+echo ""
+echo "(if you have any problems please report them at https://github.com/shyiko/jabba/issue)"

--- a/jabba.bat
+++ b/jabba.bat
@@ -1,0 +1,28 @@
+@echo off
+
+:: Set environment variables.
+set "JABBA_HOME=%USERPROFILE%\.jabba"
+set "TEMP_ENV=%TEMP%\jabba.env"
+set "TEMP_REP=%TEMP%\jabba.rep"
+set "TEMP_BAT=%TEMP%\jabba.bat"
+
+:: Run jabba, write to TEMP_ENV.
+"%JABBA_HOME%\bin\jabba.exe" %1 %2 %3 %4 %5 --fd3 "%TEMP_ENV%"
+
+if exist "%TEMP_ENV%" (
+    :: Convert from powershell to batch environment schript.
+    powershell -Command "(gc %TEMP_ENV%) -replace 'export ', 'set \"' ^| Out-File -encoding ASCII %TEMP_REP%"
+    powershell -Command "(gc %TEMP_REP%) -replace '=\"', '=' ^| Out-File -encoding ASCII %TEMP_BAT%"
+
+    :: Exectute within current shell (i.e, no call).
+    "%TEMP_BAT%"
+
+    :: Clean up files.
+    del "%TEMP_ENV%" "%TEMP_REP%" "%TEMP_BAT%"
+)
+
+:: Unset used environment variables.
+set JABBA_HOME=
+set TEMP_ENV=
+set TEMP_REP=
+set TEMP_BAT=

--- a/jabba.ps1
+++ b/jabba.ps1
@@ -1,0 +1,39 @@
+<#
+.SYNOPSIS
+A powershell wrapper for the Jabba JVM manager, commonly aliased as "jabba".
+.DESCRIPTION
+Jabba makes it possible to manage multiple JVMs on your system; you can list available JVMs, install remotely-available JVMs and most importantly, select a JVM to work with. Selecting a JVM in this case means manipulating the PATH and JAVA_HOME variables.
+
+.EXAMPLE
+Invoke-Jabba help
+
+Show the help output for the jabba executable.
+
+.EXAMPLE
+Invoke-Jabba ls
+
+List currently known and available JVMs.
+
+.EXAMPLE
+Invoke-Jabba link system@1.8.131 """C:\Program Files\Java\oracle-jdk8"""
+
+Tells Jabba about an already-installed JVM.
+
+.EXAMPLE
+Invoke-Jabba use system@1.8.131
+
+Tells jabba to activate the system installed JDK version 1.8.131.
+#>
+function Invoke-Jabba
+{
+    $env:JABBA_HOME=$env:USERPROFILE + "\.jabba"
+    $fd3=$([System.IO.Path]::GetTempFileName())
+    $command=$env:JABBA_HOME + "\bin\jabba.exe $args --fd3 $fd3"
+    & { $env:JABBA_SHELL_INTEGRATION="ON"; Invoke-Expression $command }
+    $fd3content=$(Get-Content $fd3)
+    if ($fd3content) {
+        $expression=$fd3content.replace("export ","`$env:") -join "`n"
+        if (-not $expression -eq "") { Invoke-Expression $expression }
+    }
+    Remove-Item -Force $fd3
+}


### PR DESCRIPTION
Hi Shyiko,

Here is a pull request with a batch script that makes it possible to use jabba from a regular cmd.exe. 

I additionally did a small change on install.ps1 to unhinge jabba.ps1 from it, and make it a little bit more conforming to PowerShell's way of doing things. The installer now fetches the ps1 script from the matching release version. It does the same for the batch script.

Finally, I updated the install message which now mentions the batch script and a user can choose to add it to their path in one way or the other.