### PR TITLE
Returning from function rather than exiting...

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,7 +100,7 @@ echo "    (JABBA_SHELL_INTEGRATION=ON $JABBA_HOME_TO_EXPORT/bin/jabba \"\$@\" 3>
 echo "    local exit_code=\$?"
 echo "    eval \$(cat \${fd3})"
 echo "    rm -f \${fd3}"
-echo "    (exit \${exit_code})"
+echo "    (return \${exit_code})"
 echo "}"
 echo ""
 echo "if [ ! -z \"\$(jabba alias default)\" ]; then"


### PR DESCRIPTION
This allows for more flexibility on host computers. An example is if 'exit' is aliased to run a script.