### PR TITLE
Remove usage of which to assert commands #295

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ https_proxy=${https_proxy:-$HTTPS_PROXY}
 HTTPS_PROXY=${HTTPS_PROXY:-$https_proxy}
 
 if [ "$JABBA_GET" == "" ]; then
-    if [ -f "$(which curl 2>/dev/null)" ]; then
+    if [ -z "$(curl -V 1>/dev/null)" ]; then
         JABBA_GET="curl -sL"
     else
         JABBA_GET="wget -qO-"

--- a/install.sh
+++ b/install.sh
@@ -11,17 +11,29 @@ else
     JABBA_HOME_TO_EXPORT=$JABBA_HOME
 fi
 
+has_command() {
+    if ! command -v "$1" > /dev/null 2>&1
+    then echo 1;
+    else echo 0;
+    fi
+}
+
 # curl looks for HTTPS_PROXY while wget for https_proxy
 https_proxy=${https_proxy:-$HTTPS_PROXY}
 HTTPS_PROXY=${HTTPS_PROXY:-$https_proxy}
 
 if [ "$JABBA_GET" == "" ]; then
-    if [ -z "$(curl -V 1>/dev/null)" ]; then
+    if [ 0 -eq  $(has_command curl) ]; then
         JABBA_GET="curl -sL"
-    else
+    elif [ 0 -eq $(has_command wget) ]; then
         JABBA_GET="wget -qO-"
+    else
+        echo "[ERROR] This script needs wget or curl to be installed."
+        exit 1
     fi
 fi
+
+echo "$JABBA_GET"
 
 if [ "$JABBA_VERSION" == "latest" ]; then
     # resolving "latest" to an actual tag


### PR DESCRIPTION
Remove usages of `which` command to check `curl` existence.
Most of the time `which` is not installed on the container which causes the script to use `wget`, which might not be installed.

Now scripts error out with the message if wget or curl is not installed.