### PR TITLE
Prevent over stripping a drive letter in Windows

### DIFF
--- a/command/deactivate.go
+++ b/command/deactivate.go
@@ -9,7 +9,8 @@ import (
 
 func Deactivate() ([]string, error) {
 	pth, _ := os.LookupEnv("PATH")
-	rgxp := regexp.MustCompile(regexp.QuoteMeta(filepath.Join(cfg.Dir(), "jdk")) + "[^:]+[:]")
+	plSep := string(os.PathListSeparator)
+	rgxp := regexp.MustCompile(regexp.QuoteMeta(filepath.Join(cfg.Dir(), "jdk")) + "[^" + plSep + "]+[" + plSep + "]")
 	// strip references to ~/.jabba/jdk/*, otherwise leave unchanged
 	pth = rgxp.ReplaceAllString(pth, "")
 	javaHome, overrideWasSet := os.LookupEnv("JAVA_HOME_BEFORE_JABBA")

--- a/command/deactivate_test.go
+++ b/command/deactivate_test.go
@@ -4,10 +4,14 @@ import (
 	"github.com/shyiko/jabba/cfg"
 	"os"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
 func TestDeactivate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unavailable in windows.")
+	}
 	prevPath := os.Getenv("PATH")
 	defer func() { os.Setenv("PATH", prevPath) }()
 	os.Setenv("PATH", "/usr/local/bin:"+cfg.Dir()+"/jdk/zulu@1.8.72/bin:/system-jdk/bin:/usr/bin")
@@ -41,6 +45,29 @@ func TestDeactivateInUnusedEnv(t *testing.T) {
 		"export PATH=\"/usr/local/bin:/system-jdk/bin:/usr/bin\"",
 		"export JAVA_HOME=\"/system-jdk\"",
 		"unset JAVA_HOME_BEFORE_JABBA",
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("actual: %v != expected: %v", actual, expected)
+	}
+}
+
+func TestDeactivateInWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Unavailable except in windows.")
+	}
+	prevPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", prevPath) }()
+	os.Setenv("PATH", `C:\Windows\System32;`+cfg.Dir()+`\jdk\zulu@1.8.72\bin;C:\system-jdk\bin;C:\Windows`)
+	os.Setenv("JAVA_HOME", cfg.Dir()+`\jdk\zulu@1.8.72`)
+	os.Setenv("JAVA_HOME_BEFORE_JABBA", `C:\system-jdk`)
+	actual, err := Deactivate()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	expected := []string{
+		`export PATH="C:\Windows\System32;C:\system-jdk\bin;C:\Windows"`,
+		`export JAVA_HOME="C:\system-jdk"`,
+		`unset JAVA_HOME_BEFORE_JABBA`,
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("actual: %v != expected: %v", actual, expected)

--- a/command/use.go
+++ b/command/use.go
@@ -26,7 +26,8 @@ func usePath(path string) ([]string, error) {
 		return nil, err
 	}
 	pth, _ := os.LookupEnv("PATH")
-	rgxp := regexp.MustCompile(regexp.QuoteMeta(filepath.Join(cfg.Dir(), "jdk")) + "[^:]+[:]")
+	plSep := string(os.PathListSeparator)
+	rgxp := regexp.MustCompile(regexp.QuoteMeta(filepath.Join(cfg.Dir(), "jdk")) + "[^" + plSep + "]+[" + plSep + "]")
 	// strip references to ~/.jabba/jdk/*, otherwise leave unchanged
 	pth = rgxp.ReplaceAllString(pth, "")
 	if runtime.GOOS == "darwin" {
@@ -37,7 +38,7 @@ func usePath(path string) ([]string, error) {
 		systemJavaHome, _ = os.LookupEnv("JAVA_HOME")
 	}
 	return []string{
-		"export PATH=\"" + filepath.Join(path, "bin") + string(os.PathListSeparator) + pth + "\"",
+		"export PATH=\"" + filepath.Join(path, "bin") + plSep + pth + "\"",
 		"export JAVA_HOME=\"" + path + "\"",
 		"export JAVA_HOME_BEFORE_JABBA=\"" + systemJavaHome + "\"",
 	}, nil

--- a/command/use_test.go
+++ b/command/use_test.go
@@ -19,6 +19,9 @@ func (f FileInfoMock) IsDir() bool        { return true }
 func (f FileInfoMock) Sys() interface{}   { return nil }
 
 func TestUse(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unavailable in windows.")
+	}
 	prevPath := os.Getenv("PATH")
 	defer func() { os.Setenv("PATH", prevPath) }()
 	var prevReadDir = readDir
@@ -42,6 +45,35 @@ func TestUse(t *testing.T) {
 		"export PATH=\"" + cfg.Dir() + "/jdk/1.7.2" + suffix + "/bin:/usr/local/bin:/usr/bin\"",
 		"export JAVA_HOME=\"" + cfg.Dir() + "/jdk/1.7.2" + suffix + "\"",
 		"export JAVA_HOME_BEFORE_JABBA=\"/system-jdk\"",
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("actual: %v != expected: %v", actual, expected)
+	}
+}
+
+func TestUseInWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Unavailable except in windows.")
+	}
+	prevPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", prevPath) }()
+	var prevReadDir = readDir
+	defer func() { readDir = prevReadDir }()
+	readDir = func(dirname string) ([]os.FileInfo, error) {
+		return []os.FileInfo{
+			FileInfoMock("1.6.0"), FileInfoMock("1.7.0"), FileInfoMock("1.7.2"), FileInfoMock("1.8.0"),
+		}, nil
+	}
+	os.Setenv("PATH", `C:\Windows\System32;`+cfg.Dir()+`\jdk\1.6.0\bin;C:\Windows`)
+	os.Setenv("JAVA_HOME", `C:\system-jdk`)
+	actual, err := Use("1.7")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	expected := []string{
+		`export PATH="` + cfg.Dir() + `\jdk\1.7.2\bin;C:\Windows\System32;C:\Windows"`,
+		`export JAVA_HOME="` + cfg.Dir() + `\jdk\1.7.2"`,
+		`export JAVA_HOME_BEFORE_JABBA="C:\system-jdk"`,
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("actual: %v != expected: %v", actual, expected)


### PR DESCRIPTION
This PR let `use` and `deactivate` command use an OS-specific path list separator instead of `:`.

This resolves #335.

## About test

Existing tests fails in Windows.

<details><summary>Existing test result in windows on master (dcf0285)</summary>


```console
> ver

Microsoft Windows [Version 10.0.18362.356]
> go version
go version go1.13 windows/amd64
> git rev-parse HEAD
dcf02850eddf464edb4c47495c7d1d79a9820832
> go test ./...
?       github.com/kai2nenobu/jabba     [no test files]
?       github.com/kai2nenobu/jabba/cfg [no test files]
--- FAIL: TestDeactivate (0.00s)
    deactivate_test.go:26: actual: [export PATH="/usr/local/bin:C:\Users\kai2nenobu\.jabba/jdk/zulu@1.8.72/bin:/system-jdk/bin:/usr/bin" export JAVA_HOME="/system-jdk" unset JAVA_HOME_BEFORE_JABBA] != expected: [export PATH="/usr/local/bin:/system-jdk/bin:/usr/bin" export JAVA_HOME="/system-jdk" unset JAVA_HOME_BEFORE_JABBA]
--- FAIL: TestUse (0.00s)
    use_test.go:47: actual: [export PATH="C:\Users\kai2nenobu\.jabba\jdk\1.7.2\bin;/usr/local/bin:C:\Users\kai2nenobu\.jabba/jdk/1.6.0/bin:/usr/bin" export JAVA_HOME="C:\Users\kai2nenobu\.jabba\jdk\1.7.2" export JAVA_HOME_BEFORE_JABBA="/system-jdk"] != expected: [export PATH="C:\Users\kai2nenobu\.jabba/jdk/1.7.2/bin:/usr/local/bin:/usr/bin" export JAVA_HOME="C:\Users\kai2nenobu\.jabba/jdk/1.7.2" export JAVA_HOME_BEFORE_JABBA="/system-jdk"]
FAIL
FAIL    github.com/kai2nenobu/jabba/command     0.606s
ok      github.com/kai2nenobu/jabba/command/fileiter    (cached)
ok      github.com/kai2nenobu/jabba/semver      (cached)
?       github.com/kai2nenobu/jabba/w32 [no test files]
FAIL
```

</details>

So I added new tests and let existing tests skip in Windows.  However, I'm not familiar with golang testing, please review test code and let me know if there are smarter manners.

I tested this PR in travis ci on three OSs (linux, macos, windows) and two golang versions (1.9, 1.13). See [travis ci log](https://travis-ci.org/kai2nenobu/jabba/builds/589587766) for more details.
