### PR TITLE
Use default jdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jabba ![Latest Version](https://img.shields.io/badge/latest-0.11.2-blue.svg) [![Build Status](https://travis-ci.org/shyiko/jabba.svg?branch=master)](https://travis-ci.org/shyiko/jabba)
+# jabba ![Latest Version](https://img.shields.io/github/v/release/shyiko/jabba?label=latest) [![Build Status](https://api.travis-ci.org/shyiko/jabba.svg?branch=master)](https://travis-ci.org/shyiko/jabba)
 
 Java Version Manager inspired by [nvm](https://github.com/creationix/nvm) (Node.js). Written in Go.
 

--- a/install.ps1
+++ b/install.ps1
@@ -44,6 +44,10 @@ If the problem persists - please create a ticket at https://github.com/shyiko/ja
 
 echo @"
 `$env:JABBA_HOME="$jabbaHome"
+if (Test-Path "`$env:JABBA_HOME/jdk/default") {
+    `$env:JAVA_HOME = "`$env:JABBA_HOME\jdk\default"
+    `$env:Path = "`$env:JAVA_HOME\bin;`$env:Path"
+}
 
 function jabba
 {


### PR DESCRIPTION
On windows powershell the default alias had no effect and was never used. With this commit I simply check if the default folder exists and if it does, set `JAVA_HOME` to that default directory.