### PR TITLE
Fixed to actually use 'default' jdk on Windows Powershell

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -44,6 +44,10 @@ If the problem persists - please create a ticket at https://github.com/shyiko/ja
 
 echo @"
 `$env:JABBA_HOME="$jabbaHome"
+if (Test-Path "`$env:JABBA_HOME/jdk/default") {
+    `$env:JAVA_HOME = "`$env:JABBA_HOME\jdk\default"
+    `$env:Path = "`$env:JAVA_HOME\bin;`$env:Path"
+}
 
 function jabba
 {


### PR DESCRIPTION
Previous the 'default' jdk folder was not used on windows powershell. I simply added a check to the jabba.ps1 file to see if the default folder exists and if it does it updates `PATH` and `JAVA_HOME` respectively.