### PR TITLE
maintain file encoding when appending to $profile

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -69,7 +69,7 @@ if (-not $(Test-Path $profile))
 if ("$(cat $profile | Select-String "\\jabba.ps1")" -eq "")
 {
     echo "Adding source string to $profile"
-    echo "`n$sourceJabba`n" >> "$profile"
+    echo "`n$sourceJabba`n" | Out-File -Append -Encoding ASCII "$profile"
 }
 else
 {


### PR DESCRIPTION
In powershell, the `>>` operator always encodes the data as UTF16-LE, and makes no attempt to match the encoding of the file that it is appending data to. This results in an extra byte being inserted in between every byte in the desired string when the string is appended to the file.

Using `| Out-File -Append -Encoding ASCII` instead of `>>` does not insert the extra bytes when appending to UFT8 encoded files.