### PR TITLE
Power shell install script cleanup

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -44,7 +44,7 @@ if the problem persists - please create a ticket at https://github.com/shyiko/ja
     exit 1
 }
 
-Write-Host @"
+@"
 `$env:JABBA_HOME="$jabbaHome"
 
 function jabba
@@ -59,7 +59,7 @@ function jabba
     }
     Remove-Item -Force `$fd3
 }
-"@ > $jabbaHome/jabba.ps1
+"@ | Out-File $jabbaHome/jabba.ps1
 
 $sourceJabba="if (Test-Path `"$jabbaHome\jabba.ps1`") { . `"$jabbaHome\jabba.ps1`" }"
 
@@ -71,14 +71,14 @@ if (-not $(Test-Path $profile))
 if ("$(Get-Content $profile | Select-String "\\jabba.ps1")" -eq "")
 {
     Write-Host "Adding source string to $profile"
-    Write-Host "`n$sourceJabba`n" >> "$profile"
+    "`n$sourceJabba`n" | Out-File -Append $profile
 }
 else
 {
     Write-Host "Skipped update of $profile (source string already present)"
 }
 
-. "$jabbaHome\jabba.ps1"
+. $jabbaHome\jabba.ps1
 
 Write-Host @"
 

--- a/install.ps1
+++ b/install.ps1
@@ -6,7 +6,7 @@ $jabbaVersion = if ($env:JABBA_VERSION) { $env:JABBA_VERSION } else { "latest" }
 if ($jabbaVersion -eq "latest")
 {
     # resolving "latest" to an actual tag
-    $jabbaVersion = [System.Text.Encoding]::UTF8.GetString((Invoke-WebRequest https://shyiko.github.com/jabba/latest -UseBasicParsing).Content).Trim()
+    $jabbaVersion = (Invoke-RestMethod https://api.github.com/repos/shyiko/jabba/releases/latest).body
 }
 
 if ($jabbaVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.+-]+)?$')

--- a/install.ps1
+++ b/install.ps1
@@ -15,8 +15,7 @@ if ($jabbaVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.+-]+)?$')
     exit 1
 }
 
-Write-Host "Installing v$jabbaVersion..."
-Write-Host ""
+Write-Host "Installing v$jabbaVersion...`n"
 
 New-Item -Type Directory -Force $jabbaHome/bin | Out-Null
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,15 +1,15 @@
 $ErrorActionPreference = "Stop"
 
-$jabbaHome = If ($env:JABBA_HOME) { $env:JABBA_HOME } else { If ($env:JABBA_DIR) { $env:JABBA_DIR } else { "$env:USERPROFILE\.jabba" } }
-$jabbaVersion = If ($env:JABBA_VERSION) { $env:JABBA_VERSION } else { "latest" }
+$jabbaHome = if ($env:JABBA_HOME) { $env:JABBA_HOME } else { if ($env:JABBA_DIR) { $env:JABBA_DIR } else { "$env:USERPROFILE\.jabba" } }
+$jabbaVersion = if ($env:JABBA_VERSION) { $env:JABBA_VERSION } else { "latest" }
 
-If ($jabbaVersion -eq "latest")
+if ($jabbaVersion -eq "latest")
 {
     # resolving "latest" to an actual tag
     $jabbaVersion = [System.Text.Encoding]::UTF8.GetString((wget https://shyiko.github.com/jabba/latest -UseBasicParsing).Content).Trim()
 }
 
-If ($jabbaVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.+-]+)?$')
+if ($jabbaVersion -notmatch '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.+-]+)?$')
 {
     echo "'$jabbaVersion' is not a valid version."
     exit 1
@@ -20,7 +20,7 @@ echo ""
 
 mkdir -Force $jabbaHome/bin | Out-Null
 
-If ($env:JABBA_MAKE_INSTALL -eq "true")
+if ($env:JABBA_MAKE_INSTALL -eq "true")
 {
     cp jabba.exe $jabbaHome/bin
 }
@@ -38,7 +38,7 @@ if (-not $binaryValid)
     echo "$jabbaHome\bin\jabba does not appear to be a valid binary.
 
 Check your Internet connection / proxy settings and try again.
-If the problem persists - please create a ticket at https://github.com/shyiko/jabba/issues."
+if the problem persists - please create a ticket at https://github.com/shyiko/jabba/issues."
     exit 1
 }
 


### PR DESCRIPTION
I had some experience running this on my local PowerShell install (PowerShell 7.0.1) because the script was using aliases that I've removed in my PowerShell profile. Also, the request to resolve the latest version number wasn't working because of an nginx proxy 301 redirect. I've switched that line to use the GitHub Releases API instead