### PR TITLE
Fix Powershell script to work with spaces in path

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -49,7 +49,7 @@ if the problem persists - please create a ticket at https://github.com/shyiko/ja
 function jabba
 {
     `$fd3=`$([System.IO.Path]::GetTempFileName())
-    `$command="$jabbaHome\bin\jabba.exe `$args --fd3 `$fd3"
+    `$command="& '$jabbaHome\bin\jabba.exe' `$args --fd3 ```"`$fd3```""
     & { `$env:JABBA_SHELL_INTEGRATION="ON"; Invoke-Expression `$command }
     `$fd3content=`$(Get-Content `$fd3)
     if (`$fd3content) {


### PR DESCRIPTION
The Powershell script fails if the `command` variable paths contains spaces. Usually due to the home directory path having spaces in it.