### PR TITLE
github pages has to be on github.io

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ fi
 
 if [ "$JABBA_VERSION" == "latest" ]; then
     # resolving "latest" to an actual tag
-    JABBA_VERSION=$($JABBA_GET https://shyiko.github.com/jabba/latest)
+    JABBA_VERSION=$($JABBA_GET https://shyiko.github.io/jabba/latest)
 fi
 
 # http://semver.org/spec/v2.0.0.html


### PR DESCRIPTION
Github might have jumped the gun, but this looks to break April 15th 2021. user.github.com has to be user.github.io now.

Issue described here. 
https://github.blog/changelog/2021-01-29-github-pages-will-stop-redirecting-pages-sites-from-github-com-after-april-15-2021/

I'm doing this straight on github.com, feel free to ignore this PR and recreate it yourself.