### PR TITLE
Allow `install.sh` to work for Bash emulators on Windows

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -92,6 +92,15 @@ case "$OSTYPE" in
     esac
     BINARY_URL="https://github.com/shyiko/jabba/releases/download/${JABBA_VERSION}/jabba-${JABBA_VERSION}-linux-${OSARCH}"
     ;;
+    cygwin*|msys*)
+    OS_ARCH=$(echo 'echo %PROCESSOR_ARCHITECTURE% & exit' | cmd | tail -n 1 | xargs) # xargs used to trim whitespace
+    if [ "$OS_ARCH" == "AMD64" ]; then
+        BINARY_URL="https://github.com/shyiko/jabba/releases/download/${JABBA_VERSION}/jabba-${JABBA_VERSION}-windows-amd64.exe"
+    else
+        echo "OS_ARCH='$OS_ARCH' is not a valid architecture at this point."
+        exit 1
+    fi
+    ;;
     *)
     echo "Unsupported OS $OSTYPE. If you believe this is an error -
 please create a ticket at https://github.com/shyiko/jabba/issues."


### PR DESCRIPTION
The `install.sh` script exits with the `Unsupported OS $OSTYPE` message if the script is running in a bash emulator, like Git Bash, on Windows. This PR modifies the bash install script to [recognize](https://stackoverflow.com/a/8597411/4352701) bash emulators on Windows so that the `windows-amd64.exe` build of jabba can be installed on Windows with bash. Also, this PR probably closes https://github.com/shyiko/jabba/issues/535.