### PR TITLE
Fix powershell script for non-windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Make sure to source `jabba.sh` in your environment if you skip it:
 ```sh
 [ -s "$JABBA_HOME/jabba.sh" ] && source "$JABBA_HOME/jabba.sh"
 ```
+> (in powershell)
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-Expression (
+  Invoke-WebRequest https://github.com/shyiko/jabba/raw/master/install.ps1 -UseBasicParsing
+).Content
+```
 
 > In [fish](https://fishshell.com/) command looks a little bit different - 
 `curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash; and . ~/.jabba/jabba.fish` 

--- a/install.ps1
+++ b/install.ps1
@@ -44,11 +44,12 @@ if ($env:JABBA_MAKE_INSTALL -eq "true")
 else
 {
     # $isOnWindows, see top of the file
-    # MacOSX enum value: 4
+    # macOS enum value: 6
+    # Unix enum value: 4
     if($isOnWindows){
         Invoke-WebRequest https://github.com/shyiko/jabba/releases/download/$jabbaVersion/jabba-$jabbaVersion-windows-amd64.exe -UseBasicParsing -OutFile $jabbaHome/bin/$jabbaExecutableName
     }
-    elseif([System.Environment]::OSVersion.Platform.value__ -eq 4){
+    elseif([System.Environment]::OSVersion.Platform.value__ -eq 4 || [System.Environment]::OSVersion.Platform.value__ -eq 6){
         Invoke-WebRequest https://github.com/shyiko/jabba/releases/download/$jabbaVersion/jabba-$jabbaVersion-darwin-amd64 -UseBasicParsing -OutFile $jabbaHome/bin/$jabbaExecutableName
     }else{
         $osArch = [System.Environment]::Is64BitOperatingSystem ? "amd64" : "386"

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,6 @@
 $ErrorActionPreference = "Stop"
 
+$sep = [IO.Path]::DirectorySeparatorChar
 $jabbaHome = if ($env:JABBA_HOME) { 
     $env:JABBA_HOME 
 } else { 
@@ -7,9 +8,9 @@ $jabbaHome = if ($env:JABBA_HOME) {
         $env:JABBA_DIR 
     } else {
         if($env:USERPROFILE){
-            "$env:USERPROFILE\.jabba" 
+            "$env:USERPROFILE" + $sep + ".jabba" 
         }else{
-            "$env:HOME\.jabba"
+            "$env:HOME" + $sep + ".jabba"
         }
     } 
 }
@@ -43,11 +44,11 @@ if ($env:JABBA_MAKE_INSTALL -eq "true")
 else
 {
     # $isOnWindows, see top of the file
-    # MacOSX enum value: 6
+    # MacOSX enum value: 4
     if($isOnWindows){
         Invoke-WebRequest https://github.com/shyiko/jabba/releases/download/$jabbaVersion/jabba-$jabbaVersion-windows-amd64.exe -UseBasicParsing -OutFile $jabbaHome/bin/$jabbaExecutableName
     }
-    elseif([System.Environment]::OSVersion.Platform.value__ -eq 6){
+    elseif([System.Environment]::OSVersion.Platform.value__ -eq 4){
         Invoke-WebRequest https://github.com/shyiko/jabba/releases/download/$jabbaVersion/jabba-$jabbaVersion-darwin-amd64 -UseBasicParsing -OutFile $jabbaHome/bin/$jabbaExecutableName
     }else{
         $osArch = [System.Environment]::Is64BitOperatingSystem ? "amd64" : "386"
@@ -58,17 +59,18 @@ else
 $ErrorActionPreference="SilentlyContinue"
 
 if($isOnWindows){
-    & $jabbaHome\bin\jabba --version | Out-Null
+    & "$jabbaHome\bin\$jabbaExecutableName" --version | Out-Null
+}else{
+	chmod a+x "$jabbaHome/bin/$jabbaExecutableName"
+    & "$jabbaHome/bin/$jabbaExecutableName" --version | Out-Null
 }
-else{
-    & $jabbaHome\bin\jabba.exe --version | Out-Null
-}
+
 $binaryValid = $?
 $ErrorActionPreference="Continue"
 if (-not $binaryValid)
 {
-    Write-Host @"
-$jabbaHome\bin\jabba does not appear to be a valid binary.
+    Write-Host -ForegroundColor Yellow @"
+$jabbaHome\bin\$jabbaExecutableName does not appear to be a valid binary.
 
 Check your Internet connection / proxy settings and try again.
 if the problem persists - please create a ticket at https://github.com/shyiko/jabba/issues.


### PR DESCRIPTION
This PR updates the powershell install script to also work on macOS and Linux depending on architecture. This PR also slightly updates wording/highlighting of output. Fixes #811 