### PR TITLE
add Temurin 17 for arm64

### DIFF
--- a/index.json
+++ b/index.json
@@ -1277,6 +1277,9 @@
         "1.11.0": "tgz+https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz",
         "1.8.282": "tgz+https://cdn.azul.com/zulu/bin/zulu8.52.0.23-ca-jdk8.0.282-macosx_aarch64.tar.gz",
         "1.8.275": "tgz+https://cdn.azul.com/zulu/bin/zulu8.50.0.1017-ca-jdk8.0.275-macos_aarch64.tar.gz"
+      },
+      "jdk@eclipse-temurin": {
+        "1.17.0-1.12": "tgz+https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.1_12.tar.gz"
       }
     },
     "amd64": {


### PR DESCRIPTION
adds one Temurin JDK

Only added the one I needed. I chose "Eclipse Temurin" as per https://adoptium.net/faq.html?variant=openjdk18&jvmVariant=hotspot#temurinName

I guess I could add all of Temurins releases if you so desire (which would be a tedious job: https://adoptium.net/archive.html?variant=openjdk17&jvmVariant=hotspot)